### PR TITLE
Make alignment.py sequence reconstruction O(n) instead of O(n²)

### DIFF
--- a/scripts/alignment.py
+++ b/scripts/alignment.py
@@ -12,6 +12,13 @@ If a gene is specified, the sequences will be the AA sequence of that gene
 at that node. If 'nuc' is specified, the whole genome nucleotide sequence
 at the node will be output. (this is default if no gene is specified).
 The FASTA header is the node's name in the tree.
+
+Sequence reconstruction is linear in the total number of mutations. A single
+depth-first traversal carries the parent sequence down to each child and
+applies only that child's own branch mutations -- the parent already encodes
+every ancestral mutation. A mutable buffer is mutated on descent and undone
+on ascent, so the same node sequence is produced as re-walking the full
+root->node path, but in O(total mutations) instead of O(nodes * depth).
 """
 import argparse
 import sys
@@ -25,26 +32,67 @@ from Bio.Seq import MutableSeq
 from Bio.SeqRecord import SeqRecord
 from tqdm import tqdm
 
-def apply_muts_to_root(root_seq, list_of_muts):
-    """
-    Apply a list of mutations to the root sequence
-    to find the sequence at a given node. The list of mutations
-    is ordered from root to node, so multiple mutations at the
-    same site will correctly overwrite each other
-    """
-    # make the root sequence mutable
-    root_plus_muts = MutableSeq(root_seq)
 
-    # apply all mutations to root sequence
-    for mut in list_of_muts:
-        # subtract 1 to deal with biological numbering vs python
-        mut_site = int(mut[1:-1])-1
-        # get the nucleotide that the site was mutated to
-        mutation = mut[-1]
-        # apply mutation
-        root_plus_muts[mut_site] = mutation
+def reconstruct_all_sequences(tree, root_seq, gene):
+    """
+    Reconstruct the sequence of every node in the tree in a single pass.
 
-    return root_plus_muts
+    Walks the tree once with an explicit stack (no recursion -- trees can be
+    very deep) carrying one mutable sequence buffer. Descending into a node
+    applies that node's own branch mutations; ascending undoes them, exactly
+    restoring the parent state. For every node this yields the root sequence
+    with every mutation on the root->node path applied in root->tip order
+    (a later mutation at the same site overwrites an earlier one) -- identical
+    to flattening tree.get_path(node) and applying each mutation to the root.
+
+    Returns a dict mapping each Bio.Phylo clade object to its sequence string.
+    """
+    # make the root sequence mutable; this single buffer is reused for every node
+    buf = MutableSeq(root_seq)
+    sequences = {}
+
+    # The root keeps the given root sequence unchanged: its own branch_attrs
+    # are never applied (tree.get_path() excludes the root in the original).
+    sequences[tree.root] = str(buf)
+
+    # Stack entries are ("descend", node) or ("ascend", undo_list).
+    stack = [("descend", child) for child in reversed(tree.root.clades)]
+
+    pbar = tqdm(desc="Reconstructing sequences", unit="node")
+    while stack:
+        kind, payload = stack.pop()
+
+        if kind == "ascend":
+            # Revert this node's mutations, last-applied first, so that
+            # repeated mutations at the same site unwind to the exact
+            # parent base.
+            for site, old_base in reversed(payload):
+                buf[site] = old_base
+            continue
+
+        node = payload
+        # Apply only this node's own branch mutations to the parent sequence.
+        muts = node.branch_attrs['mutations'].get(gene, [])
+        undo = []
+        for mut in muts:
+            # subtract 1 to deal with biological numbering vs python
+            mut_site = int(mut[1:-1]) - 1
+            # get the nucleotide that the site was mutated to
+            mutation = mut[-1]
+            # record the pre-change base so the descent can be undone exactly
+            undo.append((mut_site, buf[mut_site]))
+            # apply mutation
+            buf[mut_site] = mutation
+        sequences[node] = str(buf)
+
+        # The undo runs only after the whole subtree below this node is done.
+        stack.append(("ascend", undo))
+        for child in reversed(node.clades):
+            stack.append(("descend", child))
+        pbar.update(1)
+    pbar.close()
+
+    return sequences
 
 
 if __name__ == '__main__':
@@ -99,6 +147,9 @@ if __name__ == '__main__':
     # Convert tree JSON to Bio.phylo format
     tree = json_to_tree(auspice_json)
 
+    # Reconstruct every node's sequence in a single linear traversal
+    sequences = reconstruct_all_sequences(tree, root_seq, args.gene)
+
     # Initialize list to store sequence records for each node
     sequence_records = []
 
@@ -107,15 +158,10 @@ if __name__ == '__main__':
 
     for node in tqdm(nodes, desc="Processing nodes", unit="node"):
 
-        # Get path back to the root
-        path = tree.get_path(node)
-
-        # Get all mutations relative to root
-        muts = [branch.branch_attrs['mutations'].get(args.gene, []) for branch in path]
-        # Flatten the list of mutations
-        muts = [item for sublist in muts for item in sublist]
-        # Get sequence at node
-        node_seq = apply_muts_to_root(root_seq, muts)
+        # Get sequence at node (precomputed in the linear traversal above).
+        # pop() frees each reconstructed sequence as soon as it is consumed,
+        # so the dict and the output records are not both fully held at once.
+        node_seq = sequences.pop(node)
         # Strip trailing stop codons
         stripped_seq = Seq(str(node_seq).rstrip('*'))
         # Apply trimming if specified

--- a/scripts/alignment.py
+++ b/scripts/alignment.py
@@ -21,10 +21,12 @@ on ascent, so the same node sequence is produced as re-walking the full
 root->node path, but in O(total mutations) instead of O(nodes * depth).
 """
 import argparse
-import sys
-sys.setrecursionlimit(100000)
 import json
 import os
+# augur sets the Python recursion limit on import, from the AUGUR_RECURSION_LIMIT
+# env var (default 10000). json_to_tree() below recurses to tree depth, so it
+# relies on that -- set AUGUR_RECURSION_LIMIT for very deep trees. No manual
+# sys.setrecursionlimit() here: it would just be overwritten by this import.
 from augur.utils import json_to_tree
 from Bio import SeqIO
 from Bio.Seq import Seq


### PR DESCRIPTION
## Problem

`scripts/alignment.py` reconstructs every node's sequence by calling
`tree.get_path(node)` once per node — re-walking the root→node path every
time → **O(nodes × depth)**. The per-node rate collapses *within a single
run* as the loop advances. On the largest pseudomonadota markers
(~280k+ nodes) this is hours per marker.

## Fix

Reconstruct every node in a **single iterative DFS** (explicit stack — no
recursion, since trees can be very deep):

- one mutable buffer carries the parent sequence down;
- descending into a node applies only *that node's own* branch mutations;
- ascending undoes them (pre-change base recorded, unwound last-applied
  first, so repeated same-site mutations on one branch restore exactly).

Output then iterates `find_clades()` / `get_terminals()` in the **original
order** and looks each sequence up, so the FASTA is **byte-identical**, not
merely equivalent. `sequences.pop()` frees each sequence as it is consumed,
keeping peak RAM at parity with the original.

Linear in total mutations. No CLI/behavior changes: all args, inline +
sidecar root-sequence detection, gene selection, trimming, `hCoV-19/`
prefix stripping and the internal-stop-codon filter are untouched.

## Verification

Byte-identical (md5) vs the **unmodified original** on **11 A/B runs**:

| Input | Coverage | Old | New | Speedup |
|---|---|---|---|---|
| cyano TIGR01052 (9.5 KB) | smallest | 0.6s | 0.6s | 1× |
| bacillota PF00687.22 | default / `--trim` / `--tips-only` | 0.7s | 0.6s | ~1× |
| bacteroidota TIGR00396 (26 MB) | | 162s | 6.6s | **25×** |
| actinomycetota TIGR00643 (62 MB) | | 765s | 17s | **45×** |
| pseudomonadota TIGR00064 (126 MB, 322k nodes) | big | **2:54:34** | **35s** | **~299×** |
| flu-h3-xs auspice_raw (19.3k nodes) | sidecar root + genes `nuc`/`HA1`/`HA2`/`SigPep` | ~75–82s | ~1.7s | **~45×** |

Covers all 5 bac120 phyla, inline + sidecar root sequences, nucleotide +
amino-acid genes, trimming, tips-only, and trees from 4 to 322k nodes.
Peak RSS on the 126 MB marker: 4.99 GB (new) vs 4.98 GB (original).

🤖 Generated with [Claude Code](https://claude.com/claude-code)