### PR TITLE
Upload branches.tsv (tree edge-list + train/test split) alongside trajectory shards

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -417,6 +417,7 @@ rule upload:
         """
         python scripts/upload-to-s3.py \
             --upload-dir results \
+            --branches-dir data \
             --prefix {params.s3_prefix} \
             --analyses {params.analyses}
         """
@@ -431,6 +432,7 @@ rule upload_rdrp:
         """
         python scripts/upload-to-s3.py \
             --upload-dir results \
+            --branches-dir data \
             --prefix {params.s3_prefix} \
             --analyses {params.analyses}
         """

--- a/scripts/upload-to-s3.py
+++ b/scripts/upload-to-s3.py
@@ -75,6 +75,11 @@ def main():
         "--analyses", nargs="*", default=None,
         help="Explicit list of analysis names to upload (takes precedence over --filter)"
     )
+    parser.add_argument(
+        "--branches-dir", default="data",
+        help="Directory holding {analysis}/branches.tsv to upload alongside the shards "
+             "(the tree edge-list + train/test split; trajectories->tree is not invertible)"
+    )
     args = parser.parse_args()
 
     # Check required environment variables
@@ -130,6 +135,8 @@ def main():
     total_files = 0
     for dataset in datasets_to_upload:
         total_files += count_files(os.path.join(upload_dir, dataset))
+        if os.path.isfile(os.path.join(args.branches_dir, dataset, "branches.tsv")):
+            total_files += 1
     # Also count root-level files (like summary.json) unless using --filter
     if not filter_pattern:
         for f in os.listdir(upload_dir):
@@ -164,6 +171,16 @@ def main():
                     s3_key = f"{s3_analysis_prefix}/{relative_to_dataset}"
                     s3.upload_file(local_path, bucket, s3_key)
                     pbar.update(1)
+
+            # Upload branches.tsv (parent/child/hamming + train_test) from the data
+            # dir into the same prefix. The trajectories are a lossy, truncated sample
+            # of this tree (trajectories->tree is not invertible), so shipping the
+            # edge-list lets consumers recover the full tree + the exact train/test split.
+            branches_path = os.path.join(args.branches_dir, dataset, "branches.tsv")
+            if os.path.isfile(branches_path):
+                s3_analysis_prefix = get_s3_prefix_for_analysis(dataset, args.prefix)
+                s3.upload_file(branches_path, bucket, f"{s3_analysis_prefix}/branches.tsv")
+                pbar.update(1)
 
     print(f"Done! Uploaded to s3://{bucket}/{args.prefix}/")
 


### PR DESCRIPTION
## What

Ship `data/{analysis}/branches.tsv` to S3 in the same prefix as each marker's trajectory shards, so every `…/{analysis}/` prefix gains a `branches.tsv` sidecar.

`branches.tsv` columns: `parent · child · hamming · train_test` — the full tree as a parent→child edge list with per-branch substitution counts, plus the clade-level train/test label.

## Why

The trajectory shards are a **lossy, truncated sample** of the underlying tree — forwards are divergence-truncated (`div ≤ 1.0`, min-nodes), pairwise is capped (`pairwise_train_limit`) — and **trajectories → tree is not invertible**. Anyone evaluating *population-level* properties of a trained model (true diversity, branching, divergence spectrum, the exact held-out clades) needs the tree the trajectories were drawn from. `branches.tsv` is that tree; shipping it next to the shards makes it recoverable.

## How

The upload had to go in `upload-to-s3.py`, not just the Snakefile: the script **deletes all existing objects under each prefix** before re-uploading only `*.tar.zst`, so a Snakefile-side copy would be wiped on the next run. Uploading `branches.tsv` inside the script means it's re-written every run and stays consistent.

- `scripts/upload-to-s3.py`: add `--branches-dir` (default `data`); after a dataset's shards, upload `{branches_dir}/{analysis}/branches.tsv` to the same S3 prefix (`get_s3_prefix_for_analysis`, so subtree nesting still works). Counted toward the progress bar.
- `Snakefile`: pass `--branches-dir data` in the `upload` / `upload_rdrp` rules.

No new rule dependencies needed — `branches.tsv` already exists before `upload` runs (transitive input via the `trajectories`/`pairwise` rules).

## Validation

Ran the modified script end-to-end against a throwaway S3 prefix:
- `branches.tsv` uploads alongside the shards ✓
- survives the delete-then-reupload on a second run (not wiped) ✓
- byte-identical (md5) to the source ✓

Only affects future `snakemake upload` runs. (The existing bac120 `branches.tsv` were back-filled manually for all 608 markers; a regen would just re-write them identically.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)